### PR TITLE
add analytics script

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,19 +17,3 @@
         </p>
     </div>
 </div>
-<!-- Matomo -->
-<script>
-  var _paq = window._paq = window._paq || [];
-  _paq.push(["disableCookies"]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://analytics.apache.org/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '42']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="https://analytics.apache.org/matomo.php?idsite=42&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,5 +9,6 @@
     <script src="/js/jquery.min.js"></script>
     <script src="/js/bootstrap.min.js"></script>
     <script src="/js/site.js"></script>
+    <script src="/js/analytics.js"></script>
     <link rel="alternate" type="application/rss+xml" title="ASF Logging Services" href="/feed.xml">
 </head>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,53 @@
+(function () {
+    // List of URLs that do not need any analytics code
+    const noAnalyticsUrls = [
+
+
+    ];
+
+    // List of URLs that need a special version of Matomo code for obsolete websites
+    const dormantUrls = [
+        'https://logging.apache.org/flume',
+        'https://logging.apache.org/chainsaw/2.x/',
+        'https://logging.apache.org/log4php',
+        'https://logging.apache.org/log4j/1.x/',
+        'https://logging.apache.org/log4j/extras/',
+        'https://logging.apache.org/log4php/'
+    ];
+
+    function isUrlInList(url, list) {
+        return list.includes(url);
+    }
+
+    const url = window.location.href;
+
+    if (isUrlInList(url, dormantUrls)) {
+        // Load Matomo code for obsolete websites
+        var _paq = window._paq = window._paq || [];
+        _paq.push(["disableCookies"]);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function () {
+            var u = "https://analytics.apache.org/";
+            _paq.push(['setTrackerUrl', u + 'matomo.php']);
+            _paq.push(['setSiteId', '42']);
+            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+            g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+        })();
+    } else if (isUrlInList(url, noAnalyticsUrls)) {
+        // Do not load any analytics code
+        return
+    } else {
+        var _paq = window._paq = window._paq || [];
+        _paq.push(["disableCookies"]);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function () {
+            var u = "https://analytics.apache.org/";
+            _paq.push(['setTrackerUrl', u + 'matomo.php']);
+            _paq.push(['setSiteId', '42']);
+            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+            g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+        })();
+    }
+})();


### PR DESCRIPTION
Hey there,

This is part of our work at [Neighbourhoodie/](https://neighbourhood.ie/) with STF's [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience) for Log4j.

This is a PR to add a script file that can be loaded into other logging websites to load matomo analytics scripts for website based on if they are dormant or active. 

I used an example of a matomo script that we found [here](https://github.com/apache/logging-site/blob/b7d77b5d7d175311d76b19ab1c99baeecb4b45b8/_includes/footer.html#L17)

Do you maybe have an example of what a matomo script for dormant websites looks like ? 


