### PR TITLE
Proofread CVE fix versions

### DIFF
--- a/_vulnerabilities.adoc
+++ b/_vulnerabilities.adoc
@@ -32,8 +32,8 @@ We only extend this mathematical notation with set union operator (i.e., `∪`) 
 |Summary |JDBC appender is vulnerable to remote code execution in certain configurations
 |CVSS 3.x Score & Vector |6.6 MEDIUM (CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta7, 2.3.1) ∪ [2.4, 2.12.4) ∪ [2.13.0, 2.17.1)`
-|Versions fixed |`2.3.1` (for Java 6), `2.12.4` (for Java 7), or `2.17.1` (for Java 8 and later)
+|Versions affected |`[2.0-beta7, 2.3.1) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.17.1)`
+|Versions fixed |`2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.1` (for Java 8 and later)
 |===
 
 [#CVE-2021-44832-description]
@@ -45,7 +45,7 @@ This issue is fixed by limiting JNDI data source names to the `java` protocol.
 [#CVE-2021-44832-mitigation]
 ==== Mitigation
 
-Upgrade to `2.3.1` (for Java 6), `2.12.4` (for Java 7), or `2.17.1` (for Java 8 and later).
+Upgrade to `2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.1` (for Java 8 and later).
 
 In prior releases confirm that if the JDBC Appender is being used it is not configured to use any protocol other than `java`.
 
@@ -150,8 +150,8 @@ Additional vulnerability details discovered independently by Ash Fox of Google, 
 |Summary |JNDI lookup can be exploited to execute arbitrary code loaded from an LDAP server
 |CVSS 3.x Score & Vector |10.0 CRITICAL (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta9, 2.3.1) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.17.0)`
-|Versions fixed |`2.3.1` (for Java 6), `2.12.3` (for Java 7), and `2.17.0` (for Java 8 and later)
+|Versions affected |`[2.0-beta9, 2.3.1) ∪ [2.4, 2.12.2) ∪ [2.13.0, 2.17.0)`
+|Versions fixed |`2.3.1` (for Java 6), `2.12.2` (for Java 7), and `2.17.0` (for Java 8 and later)
 |===
 
 [#CVE-2021-44228-description]
@@ -180,7 +180,7 @@ Log4j 1 configurations without `JMSAppender` are not impacted by this vulnerabil
 [#CVE-2021-44228-mitigation-log4j2]
 ===== Log4j 2 mitigation
 
-Upgrade to Log4j `2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.0` (for Java 8 and later).
+Upgrade to Log4j `2.3.1` (for Java 6), `2.12.2` (for Java 7), or `2.17.0` (for Java 8 and later).
 
 [#CVE-2021-44228-credits]
 ==== Credits
@@ -203,7 +203,7 @@ This issue was discovered by Chen Zhaojun of Alibaba Cloud Security Team.
 |Summary |Improper validation of certificate with host mismatch in SMTP appender
 |CVSS 3.x Score & Vector |3.7 LOW (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta1, 2.3.2) ∪ [2.4, 2.12.2) ∪ [2.13.0, 2.13.2)`
+|Versions affected |`[2.0-beta1, 2.3.2) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.13.2)`
 |Versions fixed |`2.3.2` (for Java 6), `2.12.3` (for Java 7) and `2.13.2` (for Java 8 and later)
 |===
 

--- a/_vulnerabilities.adoc
+++ b/_vulnerabilities.adoc
@@ -32,8 +32,8 @@ We only extend this mathematical notation with set union operator (i.e., `∪`) 
 |Summary |JDBC appender is vulnerable to remote code execution in certain configurations
 |CVSS 3.x Score & Vector |6.6 MEDIUM (CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta7, 2.3.2) ∪ [2.4, 2.12.4) ∪ [2.13.0, 2.17.1)`
-|Versions fixed |`2.3.2` (for Java 6), `2.12.4` (for Java 7), or `2.17.1` (for Java 8 and later)
+|Versions affected |`[2.0-beta7, 2.3.1) ∪ [2.4, 2.12.4) ∪ [2.13.0, 2.17.1)`
+|Versions fixed |`2.3.1` (for Java 6), `2.12.4` (for Java 7), or `2.17.1` (for Java 8 and later)
 |===
 
 [#CVE-2021-44832-description]
@@ -45,13 +45,14 @@ This issue is fixed by limiting JNDI data source names to the `java` protocol.
 [#CVE-2021-44832-mitigation]
 ==== Mitigation
 
-Upgrade to `2.3.2` (for Java 6), `2.12.4` (for Java 7), or `2.17.1` (for Java 8 and later).
+Upgrade to `2.3.1` (for Java 6), `2.12.4` (for Java 7), or `2.17.1` (for Java 8 and later).
 
 In prior releases confirm that if the JDBC Appender is being used it is not configured to use any protocol other than `java`.
 
 [#CVE-2021-44832-references]
 ==== References
 - {cve-url-prefix}/CVE-2021-44832[CVE-2021-44832]
+- https://issues.apache.org/jira/browse/LOG4J2-3242[LOG4J2-3242]
 
 [#CVE-2021-45105]
 === {cve-url-prefix}/CVE-2021-45105[CVE-2021-45105]
@@ -192,6 +193,7 @@ This issue was discovered by Chen Zhaojun of Alibaba Cloud Security Team.
 - {cve-url-prefix}/CVE-2021-44228[CVE-2021-44228]
 - https://issues.apache.org/jira/browse/LOG4J2-3198[LOG4J2-3198]
 - https://issues.apache.org/jira/browse/LOG4J2-3201[LOG4J2-3201]
+- https://issues.apache.org/jira/browse/LOG4J2-3242[LOG4J2-3242]
 
 [#CVE-2020-9488]
 === {cve-url-prefix}/CVE-2020-9488[CVE-2020-9488]
@@ -201,8 +203,8 @@ This issue was discovered by Chen Zhaojun of Alibaba Cloud Security Team.
 |Summary |Improper validation of certificate with host mismatch in SMTP appender
 |CVSS 3.x Score & Vector |3.7 LOW (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta1, 2.12.3) ∪ [2.13.1, 2.13.2)`
-|Versions fixed |`2.12.3` (Java 7) and `2.13.2` (Java 8 and later)
+|Versions affected |`[2.0-beta1, 2.3.2) ∪ [2.4, 2.12.2) ∪ [2.13.0, 2.13.2)`
+|Versions fixed |`2.3.2` (for Java 6), `2.12.3` (for Java 7) and `2.13.2` (for Java 8 and later)
 |===
 
 [#CVE-2020-9488-description]
@@ -220,7 +222,7 @@ Usages of `SslConfiguration` that are configured via system properties are not a
 [#CVE-2020-9488-mitigation]
 ==== Mitigation
 
-Upgrade to `2.12.3` (Java 7) or `2.13.2` (Java 8 and later).
+Upgrade to `2.3.2` (Java 6), `2.12.3` (Java 7) or `2.13.2` (Java 8 and later).
 
 Alternatively, users can set the `mail.smtp.ssl.checkserveridentity` system property to `true` to enable SMTPS hostname verification for all SMTPS mail sessions.
 
@@ -244,7 +246,7 @@ This issue was discovered by Peter Stöckli.
 |CVSS 2.0 Score & Vector |7.5 HIGH (AV:N/AC:L/Au:N/C:P/I:P/A:P)
 |Components affected |`log4j-core`
 |Versions affected |`[2.0-alpha1, 2.8.2)`
-|Versions fixed |`2.8.2` (Java 7)
+|Versions fixed |`2.8.2` (for Java 7 and later)
 |===
 
 [#CVE-2017-5645-description]

--- a/_vulnerabilities.adoc
+++ b/_vulnerabilities.adoc
@@ -32,8 +32,8 @@ We only extend this mathematical notation with set union operator (i.e., `∪`) 
 |Summary |JDBC appender is vulnerable to remote code execution in certain configurations
 |CVSS 3.x Score & Vector |6.6 MEDIUM (CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta7, 2.3.1) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.17.1)`
-|Versions fixed |`2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.1` (for Java 8 and later)
+|Versions affected |`[2.0-beta7, 2.3.1) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.17.0)`
+|Versions fixed |`2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.0` (for Java 8 and later)
 |===
 
 [#CVE-2021-44832-description]
@@ -45,7 +45,7 @@ This issue is fixed by limiting JNDI data source names to the `java` protocol.
 [#CVE-2021-44832-mitigation]
 ==== Mitigation
 
-Upgrade to `2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.1` (for Java 8 and later).
+Upgrade to `2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.0` (for Java 8 and later).
 
 In prior releases confirm that if the JDBC Appender is being used it is not configured to use any protocol other than `java`.
 
@@ -107,8 +107,8 @@ Independently discovered by Hideki Okamoto of Akamai Technologies, Guy Lederfein
 |Summary |Thread Context Lookup is vulnerable to remote code execution in certain configurations
 |CVSS 3.x Score & Vector |9.0 CRITICAL (CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta9, 2.3.1) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.17.0)`
-|Versions fixed |`2.3.1` (for Java 6), `2.12.3` (for Java 7), and `2.17.0` (for Java 8 and later)
+|Versions affected |`[2.0-beta9, 2.3.1) ∪ [2.4, 2.12.3) ∪ [2.13.0, 2.16.0)`
+|Versions fixed |`2.3.1` (for Java 6), `2.12.3` (for Java 7), and `2.16.0` (for Java 8 and later)
 |===
 
 [#CVE-2021-45046-description]
@@ -127,7 +127,7 @@ Applications using only the `log4j-api` JAR file without the `log4j-core` JAR fi
 [#CVE-2021-45046-mitigation]
 ==== Mitigation
 
-Upgrade to Log4j `2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.17.0` (for Java 8 and later).
+Upgrade to Log4j `2.3.1` (for Java 6), `2.12.3` (for Java 7), or `2.16.0` (for Java 8 and later).
 
 [#CVE-2021-45046-credits]
 ==== Credits
@@ -150,8 +150,8 @@ Additional vulnerability details discovered independently by Ash Fox of Google, 
 |Summary |JNDI lookup can be exploited to execute arbitrary code loaded from an LDAP server
 |CVSS 3.x Score & Vector |10.0 CRITICAL (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H)
 |Components affected |`log4j-core`
-|Versions affected |`[2.0-beta9, 2.3.1) ∪ [2.4, 2.12.2) ∪ [2.13.0, 2.17.0)`
-|Versions fixed |`2.3.1` (for Java 6), `2.12.2` (for Java 7), and `2.17.0` (for Java 8 and later)
+|Versions affected |`[2.0-beta9, 2.3.1) ∪ [2.4, 2.12.2) ∪ [2.13.0, 2.15.0)`
+|Versions fixed |`2.3.1` (for Java 6), `2.12.2` (for Java 7), and `2.15.0` (for Java 8 and later)
 |===
 
 [#CVE-2021-44228-description]
@@ -180,7 +180,7 @@ Log4j 1 configurations without `JMSAppender` are not impacted by this vulnerabil
 [#CVE-2021-44228-mitigation-log4j2]
 ===== Log4j 2 mitigation
 
-Upgrade to Log4j `2.3.1` (for Java 6), `2.12.2` (for Java 7), or `2.17.0` (for Java 8 and later).
+Upgrade to Log4j `2.3.1` (for Java 6), `2.12.2` (for Java 7), or `2.15.0` (for Java 8 and later).
 
 [#CVE-2021-44228-credits]
 ==== Credits


### PR DESCRIPTION
This PR double checks which Log4j Core versions resolved which vulnerabilities.

## Branch `2.3.x`

**https://github.com/advisories/GHSA-fxph-q3j8-mv87** / **CVE-2017-5645** (server class) was never fixed, the TCP/UDP socket server is still there.

**https://github.com/advisories/GHSA-vwqq-5vrc-xw9h** / **CVE-2020-9488** (host name validation) was fixed in `2.3.2`:

- https://github.com/apache/logging-log4j2/commit/3c62f0bea692456b1b5039d3bcc1c3e0ba65146a

**https://github.com/advisories/GHSA-jfh8-c2jp-5v3q** / **CVE-2021-44228** (Log4Shell) was fixed in `2.3.1`:

- https://github.com/apache/logging-log4j2/commit/be848dacbac6df30c4f32b2852e24446033ecf79
- https://github.com/apache/logging-log4j2/commit/f6564bb993d547d0a371b75d869042c334bf57f0

**https://github.com/advisories/GHSA-7rjr-3q55-vv33** / **CVE-2021-45046** (Log4Shell through recursive lookup evaluation) was fixed in `2.3.1`:

- https://github.com/apache/logging-log4j2/commit/f6564bb993d547d0a371b75d869042c334bf57f0

**https://github.com/advisories/GHSA-p6xc-xr62-6r2g** / **CVE-2021-45105** (DoS through recursive lookup evaluation) was fixed in `2.3.1`:

- https://github.com/apache/logging-log4j2/commit/ce6b78d082aae89089cb3ad25cdd46e9ec70a70b

**https://github.com/advisories/GHSA-8489-44mv-ggj8** / **CVE-2021-44832** (RCE if you have access to application classpath/configuration) was fixed in `2.3.1`:

- https://github.com/apache/logging-log4j2/commit/f6564bb993d547d0a371b75d869042c334bf57f0

## Branch `2.12.x`

**https://github.com/advisories/GHSA-vwqq-5vrc-xw9h** / **CVE-2020-9488** (host name validation) was fixed in `2.12.3`:

- https://github.com/apache/logging-log4j2/commit/2bcba12b185200b7f3f2532cbfeff1e1da0d5c81
- https://github.com/apache/logging-log4j2/commit/bb94ea9fa921a61f90b6a934600567e719419ddd

**https://github.com/advisories/GHSA-jfh8-c2jp-5v3q** / **CVE-2021-44228** (Log4Shell) was fixed in `2.12.2`:

- https://github.com/apache/logging-log4j2/commit/70edc233343815d5efa043b54294a6fb065aa1c5
- https://github.com/apache/logging-log4j2/commit/f819c83804152cb6ed94cb408302e36b21b65053

**https://github.com/advisories/GHSA-7rjr-3q55-vv33** / **CVE-2021-45046** (Log4Shell through recursive lookup evaluation) was fixed in `2.12.3`:

- https://github.com/apache/logging-log4j2/commit/bf8ba18f63ab9f9ffd54387c5c527ecc7a681037

**https://github.com/advisories/GHSA-p6xc-xr62-6r2g** / **CVE-2021-45105** (DoS through recursive lookup evaluation) was fixed in `2.12.3`:

- https://github.com/apache/logging-log4j2/commit/bf7e916df6335713fe2219c7b3b523fb509deabc

**https://github.com/advisories/GHSA-8489-44mv-ggj8** / **CVE-2021-44832** (RCE if you have access to application classpath/configuration) was fixed in `2.12.3`:

- https://github.com/apache/logging-log4j2/commit/bf8ba18f63ab9f9ffd54387c5c527ecc7a681037

**Note**: Unless I am mistaken, version `2.12.4` didn't contain any security updates.

## Main `2.x` branch

**https://github.com/advisories/GHSA-jfh8-c2jp-5v3q** / **CVE-2021-44228** (Log4Shell) was fixed in `2.15.0`:

- https://github.com/apache/logging-log4j2/commit/c77b3cb39312b83b053d23a2158b99ac7de44dd3
- https://github.com/apache/logging-log4j2/commit/001aaada7dab82c3c09cde5f8e14245dc9d8b454

**https://github.com/advisories/GHSA-7rjr-3q55-vv33** / **CVE-2021-45046** (Log4Shell through recursive lookup evaluation) was fixed in `2.16.0`:

- https://github.com/apache/logging-log4j2/commit/c362aff473e9812798ff8f25f30a2619996605d5
- https://github.com/apache/logging-log4j2/commit/27972043b76c9645476f561c5adc483dec6d3f5d

**https://github.com/advisories/GHSA-p6xc-xr62-6r2g** / **CVE-2021-45105** (DoS through recursive lookup evaluation) was fixed in `2.17.0`:

- https://github.com/apache/logging-log4j2/commit/806023265f8c905b2dd1d81fd2458f64b2ea0b5e

**https://github.com/advisories/GHSA-8489-44mv-ggj8** / **CVE-2021-44832** (RCE if you have access to application classpath/configuration) was fixed in `2.17.0`:

- https://github.com/apache/logging-log4j2/commit/95b24f77e77e4f1e5cc794df5332643e944fd6f8

**Note**: Unless I am mistaken, version `2.17.1` didn't contain any security updates.