### PR TITLE
Upgrade Jekyll docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ruby:2.7.1-alpine3.11 as dependencies
+FROM ruby:alpine AS dependencies
 
 RUN apk --no-cache add \
   zlib-dev \
@@ -30,9 +30,7 @@ RUN apk --no-cache add \
   zlib-dev \
   vips-dev \
   sqlite-dev \
-  cmake
-
-RUN apk --no-cache add \
+  cmake \
   linux-headers \
   openjdk8-jre \
   less \
@@ -47,17 +45,14 @@ RUN apk --no-cache add \
   shadow \
   bash \
   su-exec \
-  nodejs-npm \
+  npm \
   libressl \
   yarn
 
 WORKDIR /root/build
 
-RUN gem install bundler:1.17.3
-ENV BUNDLE_CLEAN=false
-
+RUN gem install bundler
 COPY Gemfile .
-
 RUN bundle config clean
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.2.2"
+gem "jekyll", "~> 4.4.1"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5.2"
@@ -42,3 +42,8 @@ group :jekyll_plugins do
   gem "jekyll-asciidoc", "~> 2.1.1"
   gem "jekyll-sass-converter", "~> 2.2.0"
 end
+
+# After upgrade to Jekyll 4.4
+gem "rouge", "~> 3.30"
+gem "terminal-table", "~> 2.0"
+gem "unicode-display_width", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -22,25 +22,23 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.2.0"
+gem "jekyll", "~> 4.2.2"
+
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.5"
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+gem "minima", "~> 2.5.2"
+
+# To run Jekyll on Ruby 3.0 or higher
+gem "webrick", "~> 1.9"
+# To run Jekyll on Ruby 3.4 or higher
+gem "base64", "~> 0.2.0"
+gem "bigdecimal", "~> 3.1"
+gem "csv", "~> 3.3"
+# To run Jekyll on Ruby 3.5 or higher
+gem "logger", "~> 1.6"
+
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.12"
-  gem 'jekyll-asciidoc', '~> 2.1.1'
+  gem "jekyll-feed", "~> 0.17.0"
+  gem "jekyll-asciidoc", "~> 2.1.1"
+  gem "jekyll-sass-converter", "~> 2.2.0"
 end
-
-# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
-# and associated library.
-platforms :mingw, :x64_mingw, :mswin, :jruby do
-  gem "tzinfo", "~> 1.2"
-  gem "tzinfo-data"
-end
-
-# Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-

--- a/run-jekyll.sh
+++ b/run-jekyll.sh
@@ -13,4 +13,8 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
-docker run --rm -p 4000:4000 --mount type=bind,src=$PWD,dst=/root/build --mount type=volume,dst=/root/build/node_modules -it apache/logging_site serve --watch
+docker run --rm -it\
+  -p 4000:4000\
+   --mount type=bind,src=$PWD,dst=/root/build\
+   --mount type=volume,dst=/root/build/node_modules\
+   apache/logging_site serve --watch


### PR DESCRIPTION
This change upgrades Jekyll's docker file, since the old images are no longer available.