### PR TITLE
Set `target-path` to `content` in `deploy-site.yaml`

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -43,6 +43,11 @@ jobs:
           whoami: ${{ github.ref_name }}-site-stg-out
           subdir: content/
       target-branch: ${{ github.ref_name }}-site-stg-out
+      # For some unknown reason, `target-path` needs to be `content`.
+      # Fortunately, it is only `logging-site` that needs to implement this hack.
+      # Other `logging-*` repositories using `deploy-site-reusable.yaml` can continue using the default `target-path`.
+      # See https://issues.apache.org/jira/browse/INFRA-27533
+      target-path: content
 
   deploy-site-pro:
     if: github.repository == 'apache/logging-site' && github.ref_name == 'main-site-pro'
@@ -59,3 +64,8 @@ jobs:
           whoami: ${{ github.ref_name }}-out
           subdir: content/
       target-branch: ${{ github.ref_name }}-out
+      # For some unknown reason, `target-path` needs to be `content`.
+      # Fortunately, it is only `logging-site` that needs to implement this hack.
+      # Other `logging-*` repositories using `deploy-site-reusable.yaml` can continue using the default `target-path`.
+      # See https://issues.apache.org/jira/browse/INFRA-27533
+      target-path: content


### PR DESCRIPTION
Site content only gets served it is placed under the `content` folder, see [INFRA-27533].

[INFRA-27533]: https://issues.apache.org/jira/browse/INFRA-27533