### PR TITLE
Add CVEs for the 2026-04 releases

### DIFF
--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,45 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-40023]
+== {cve-url-prefix}/CVE-2026-40023[CVE-2026-40023]
+
+[cols="1h,5"]
+|===
+|Summary |Silent log event loss in `XMLLayout` due to unescaped XML 1.0 forbidden characters
+|CVSS 4.x Score & Vector |6.3 MEDIUM (CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |Log4cxx
+|Versions affected |`[0, 1.7.0)`
+|Versions fixed |`1.7.0`
+|===
+
+[#CVE-2026-40023-description]
+=== Description
+
+Apache Log4cxx's
+https://logging.apache.org/log4cxx/1.7.0/classlog4cxx_1_1xml_1_1XMLLayout.html[`XMLLayout`],
+in versions before 1.7.0, fails to sanitize characters forbidden by the
+https://www.w3.org/TR/xml/#charsets[XML 1.0 specification]
+in log messages, NDC, and MDC property keys and values, producing invalid XML output.
+Conforming XML parsers must reject such documents with a fatal error, which may cause downstream log processing systems to drop or fail to index affected records.
+
+An attacker who can influence logged data can exploit this to suppress individual log records, impairing audit trails and detection of malicious activity.
+
+[#CVE-2026-40023-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4cxx version `1.7.0`, which fixes this issue.
+
+[#CVE-2026-40023-credits]
+=== Credits
+
+This issue was discovered by Olawale Titiloye.
+
+[#CVE-2026-40023-references]
+=== References
+* {cve-url-prefix}/CVE-2026-40023[CVE-2026-40023]
+* https://github.com/apache/logging-log4cxx/pull/609[Pull request that fixes the issue]
+
 [#CVE-2026-40021]
 == {cve-url-prefix}/CVE-2026-40021[CVE-2026-40021]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -334,7 +334,7 @@ This issue was originally reported by Samuli Leinonen and independently reported
 |Summary |Missing TLS hostname verification in Socket appender
 |CVSS 4.x Score & Vector |6.3 MEDIUM (CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:L/SA:N)
 |Components affected |Log4j Core
-|Versions affected |`[2.0-beta9, 2.25.3) ∪ [3.0.0-alpha1, 3.0.0-beta3]Ba`
+|Versions affected |`[2.0-beta9, 2.25.3) ∪ [3.0.0-alpha1, 3.0.0-beta3]`
 |Versions fixed |`2.25.3`
 |===
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,47 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-40021]
+== {cve-url-prefix}/CVE-2026-40021[CVE-2026-40021]
+
+[cols="1h,5"]
+|===
+|Summary |Silent log event loss in `XmlLayout` and `XmlLayoutSchemaLog4J` due to unescaped XML 1.0 forbidden characters
+|CVSS 4.x Score & Vector |6.3 MEDIUM (CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |Log4net
+|Versions affected |`[0, 3.3.0)`
+|Versions fixed |`3.3.0`
+|===
+
+[#CVE-2026-40021-description]
+=== Description
+
+Apache Log4net's
+https://logging.apache.org/log4net/manual/configuration/layouts.html#layout-list[`XmlLayout`]
+and
+https://logging.apache.org/log4net/manual/configuration/layouts.html#layout-list[`XmlLayoutSchemaLog4J`],
+in versions before 3.3.0, fail to sanitize characters forbidden by the
+https://www.w3.org/TR/xml/#charsets[XML 1.0 specification]
+in MDC property keys and values, as well as the identity field that may carry attacker-influenced data.
+This causes an exception during serialization and the silent loss of the affected log event.
+
+An attacker who can influence any of these fields can exploit this to suppress individual log records, impairing audit trails and detection of malicious activity.
+
+[#CVE-2026-40021-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4net version `3.3.0`, which fixes this issue.
+
+[#CVE-2026-40021-credits]
+=== Credits
+
+This issue was discovered by f00dat.
+
+[#CVE-2026-40021-references]
+=== References
+* {cve-url-prefix}/CVE-2026-40021[CVE-2026-40021]
+* https://github.com/apache/logging-log4net/pull/280[Pull request that fixes the issue]
+
 [#CVE-2026-34481]
 == {cve-url-prefix}/CVE-2026-34481[CVE-2026-34481]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,54 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-34477]
+== {cve-url-prefix}/CVE-2026-34477[CVE-2026-34477]
+
+[cols="1h,5"]
+|===
+|Summary |`verifyHostName` attribute silently ignored in TLS configuration
+|CVSS 4.x Score & Vector |6.3 MEDIUM (CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |Log4j Core
+|Versions affected |`[2.12.0, 2.25.4) ∪ [3.0.0-alpha1, 3.0.0-beta3]`
+|Versions fixed |`2.25.4`
+|===
+
+[#CVE-2026-34477-description]
+=== Description
+
+The fix for <<CVE-2025-68161>> was incomplete: it addressed hostname verification only when enabled via the
+https://logging.apache.org/log4j/2.x/manual/systemproperties.html#log4j2.sslVerifyHostName[`log4j2.sslVerifyHostName`]
+system property, but not when configured through the
+https://logging.apache.org/log4j/2.x/manual/appenders/network.html#SslConfiguration-attr-verifyHostName[`verifyHostName`]
+attribute of the `<Ssl>` element.
+
+Although the `verifyHostName` configuration attribute was introduced in Log4j Core 2.12.0, it was silently ignored in all versions through 2.25.3, leaving TLS connections vulnerable to interception regardless of the configured value.
+
+A network-based attacker may be able to perform a man-in-the-middle attack when *all* of the following conditions are met:
+
+* An SMTP, Socket, or Syslog appender is in use.
+* TLS is configured via a nested `<Ssl>` element.
+* The attacker can present a certificate issued by a CA trusted by the appender's configured trust store, or by the default Java trust store if none is configured.
+
+This issue does not affect users of the HTTP appender, which uses a separate
+https://logging.apache.org/log4j/2.x/manual/appenders/network.html#HttpAppender-attr-verifyHostName[`verifyHostname`]
+attribute that was not subject to this bug and verifies host names by default.
+
+[#CVE-2026-34477-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4j Core version `2.25.4`, which corrects this issue.
+
+[#CVE-2026-34477-credits]
+=== Credits
+
+This issue was originally reported by Samuli Leinonen and independently reported by Naresh Kandula, Vitaly Simonovich, Raijuna, Danish Siddiqui (djvirus), Markus Magnuson, and Haruki Oyama (Waseda University).
+
+[#CVE-2026-34477-references]
+=== References
+* {cve-url-prefix}/CVE-2026-34477[CVE-2026-34477]
+* https://github.com/apache/logging-log4j2/pull/4075[Pull request that fixes the issue]
+
 [#CVE-2025-68161]
 == {cve-url-prefix}/CVE-2025-68161[CVE-2025-68161]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -37,7 +37,7 @@ For brevity, mathematical interval notation is used, with the union operator (`â
 |Summary |Missing TLS hostname verification in Socket appender
 |CVSS 4.x Score & Vector |6.3 MEDIUM (CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:L/SA:N)
 |Components affected |Log4j Core
-|Versions affected |`[2.0-beta9, 2.25.3)`
+|Versions affected |`[2.0-beta9, 2.25.3) âˆª [3.0.0-alpha1, 3.0.0-beta3]Ba`
 |Versions fixed |`2.25.3`
 |===
 
@@ -128,7 +128,7 @@ This issue was discovered and remediated with support from the Sovereign Tech Ag
 === Description
 
 When using `HTMLLayout`, logger names are not properly escaped when writing out to the HTML file.
-If untrusted data is used to retrieve the name of a logger, an attacker could theoretically inject HTML or Javascript in order to hide information from logs or steal data from the user.
+If untrusted data is used to retrieve the name of a logger, an attacker could theoretically inject HTML or JavaScript in order to hide information from logs or steal data from the user.
 In order to activate this, the following sequence must occur:
 
 * Log4cxx is configured to use `HTMLLayout`.

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,46 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-34481]
+== {cve-url-prefix}/CVE-2026-34481[CVE-2026-34481]
+
+[cols="1h,5"]
+|===
+|Summary |Improper serialization of non-finite floating-point values in `JsonTemplateLayout`
+|CVSS 4.x Score & Vector |6.3 MEDIUM (CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |`log4j-layout-template-json`
+|Versions affected |`[2.14.0, 2.25.4) ∪ [3.0.0-alpha1, 3.0.0-beta3]`
+|Versions fixed |`2.25.4`
+|===
+
+[#CVE-2026-34481-description]
+=== Description
+
+Apache Log4j's
+https://logging.apache.org/log4j/2.x/manual/json-template-layout.html[`JsonTemplateLayout`],
+in versions up to and including 2.25.3, produces invalid JSON output when log events contain non-finite floating-point values (`NaN`, `Infinity`, or `-Infinity`), which are prohibited by RFC 8259.
+This may cause downstream log processing systems to reject or fail to index affected records.
+
+An attacker can exploit this issue only if both of the following conditions are met:
+
+* The application uses `JsonTemplateLayout`.
+* The application logs a `MapMessage` containing an attacker-controlled floating-point value.
+
+[#CVE-2026-34481-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4j JSON Template Layout version `2.25.4`, which corrects this issue.
+
+[#CVE-2026-34481-credits]
+=== Credits
+
+This issue was discovered by Ap4sh (Samy Medjahed) and Ethicxz (Eliott Laurie).
+
+[#CVE-2026-34481-references]
+=== References
+* {cve-url-prefix}/CVE-2026-34481[CVE-2026-34481]
+* https://github.com/apache/logging-log4j2/pull/4080[Pull request that fixes the issue]
+
 [#CVE-2026-34480]
 == {cve-url-prefix}/CVE-2026-34480[CVE-2026-34480]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,52 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-34479]
+== {cve-url-prefix}/CVE-2026-34479[CVE-2026-34479]
+
+[cols="1h,5"]
+|===
+|Summary |Silent log event loss in `Log4j1XmlLayout` due to unescaped XML 1.0 forbidden characters
+|CVSS 4.x Score & Vector |6.9 MEDIUM (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |`log4j-1.2-api`
+|Versions affected |`[2.7, 2.25.4) ∪ [3.0.0-alpha1, 3.0.0-beta2]`
+|Versions fixed |`2.25.4`
+|===
+
+[#CVE-2026-34479-description]
+=== Description
+
+The `Log4j1XmlLayout` from the Apache Log4j 1-to-Log4j 2 bridge fails to escape characters forbidden by the XML 1.0 standard, producing malformed XML output.
+Conforming XML parsers are required to reject documents containing such characters with a fatal error, which may cause downstream log processing systems to drop or fail to index affected records.
+
+Two groups of users are affected:
+
+* Those using `Log4j1XmlLayout` directly in a Log4j Core 2 configuration file.
+* Those using the Log4j 1 configuration compatibility layer with `org.apache.log4j.xml.XMLLayout` specified as the layout class.
+
+[#CVE-2026-34479-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4j 1-to-Log4j 2 bridge version `2.25.4`, which corrects this issue.
+
+[NOTE]
+====
+The Apache Log4j 1-to-Log4j 2 bridge is deprecated and will not be present in Log4j 3.
+Users are encouraged to consult the
+https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html[Log4j 1 to Log4j 2 migration guide],
+and specifically the section on eliminating reliance on the bridge.
+====
+
+[#CVE-2026-34479-credits]
+=== Credits
+
+This issue was originally reported by Ap4sh (Samy Medjahed) and Ethicxz (Eliott Laurie), and independently reported by jabaltarik1.
+
+[#CVE-2026-34479-references]
+=== References
+* {cve-url-prefix}/CVE-2026-34479[CVE-2026-34479]
+* https://github.com/apache/logging-log4j2/pull/4078[Pull request that fixes the issue]
+
 [#CVE-2026-34478]
 == {cve-url-prefix}/CVE-2026-34478[CVE-2026-34478]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,47 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-34478]
+== {cve-url-prefix}/CVE-2026-34478[CVE-2026-34478]
+
+[cols="1h,5"]
+|===
+|Summary |Log injection in `Rfc5424Layout` due to silent configuration incompatibility
+|CVSS 4.x Score & Vector |6.9 MEDIUM (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |Log4j Core
+|Versions affected |`[2.21.0, 2.25.4) ∪ [3.0.0-beta1, 3.0.0-beta3]`
+|Versions fixed |`2.25.4`
+|===
+
+[#CVE-2026-34478-description]
+=== Description
+
+Apache Log4j Core's
+https://logging.apache.org/log4j/2.x/manual/layouts.html#RFC5424Layout[`Rfc5424Layout`],
+in versions 2.21.0 through 2.25.3, is vulnerable to log injection via CRLF sequences due to undocumented renames of security-relevant configuration attributes.
+
+Two distinct issues affect users of stream-based syslog services who configure `Rfc5424Layout` directly:
+
+* The `newLineEscape` attribute was silently renamed, causing newline escaping to stop working for users of TCP framing (RFC 6587), exposing them to CRLF injection in log output.
+* The `useTlsMessageFormat` attribute was silently renamed, causing users of TLS framing (RFC 5425) to be silently downgraded to unframed TCP (RFC 6587), without newline escaping.
+
+Users of the `SyslogAppender` are not affected, as its configuration attributes were not modified.
+
+[#CVE-2026-34478-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4j Core version `2.25.4`, which corrects this issue.
+
+[#CVE-2026-34478-credits]
+=== Credits
+
+This issue was discovered by Samuli Leinonen.
+
+[#CVE-2026-34478-references]
+=== References
+* {cve-url-prefix}/CVE-2026-34478[CVE-2026-34478]
+* https://github.com/apache/logging-log4j2/pull/4074[Pull request that fixes the issue]
+
 [#CVE-2026-34477]
 == {cve-url-prefix}/CVE-2026-34477[CVE-2026-34477]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -29,6 +29,48 @@ Version ranges follow the https://github.com/package-url/vers-spec/blob/main/VER
 For brevity, mathematical interval notation is used, with the union operator (`∪`) to represent multiple ranges.
 ====
 
+[#CVE-2026-34480]
+== {cve-url-prefix}/CVE-2026-34480[CVE-2026-34480]
+
+[cols="1h,5"]
+|===
+|Summary |Silent log event loss in `XmlLayout` due to unescaped XML 1.0 forbidden characters
+|CVSS 4.x Score & Vector |6.9 MEDIUM (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N)
+|Components affected |Log4j Core
+|Versions affected |`[2.0-alpha1, 2.25.4) ∪ [3.0.0-alpha1, 3.0.0-beta3]`
+|Versions fixed |`2.25.4`
+|===
+
+[#CVE-2026-34480-description]
+=== Description
+
+Apache Log4j Core's
+https://logging.apache.org/log4j/2.x/manual/layouts.html#XmlLayout[`XmlLayout`],
+in versions up to and including 2.25.3, fails to sanitize characters forbidden by the
+https://www.w3.org/TR/xml/#charsets[XML 1.0 specification]
+producing invalid XML output whenever a log message or MDC value contains such characters.
+
+The impact depends on the StAX implementation in use:
+
+* *JRE built-in StAX:* Forbidden characters are silently written to the output, producing malformed XML.
+Conforming parsers must reject such documents with a fatal error, which may cause downstream log-processing systems to drop the affected records.
+* *Alternative StAX implementations* (e.g., https://github.com/FasterXML/woodstox[Woodstox], a transitive dependency of the Jackson XML Dataformat module): An exception is thrown during the logging call, and the log event is never delivered to its intended appender, only to Log4j's internal status logger.
+
+[#CVE-2026-34480-remediation]
+=== Remediation
+
+Users are advised to upgrade to Apache Log4j Core version `2.25.4`, which corrects this issue by sanitizing forbidden characters before XML output.
+
+[#CVE-2026-34480-credits]
+=== Credits
+
+This issue was originally reported by Ap4sh (Samy Medjahed) and Ethicxz (Eliott Laurie), and independently reported by jabaltarik1.
+
+[#CVE-2026-34480-references]
+=== References
+* {cve-url-prefix}/CVE-2026-34480[CVE-2026-34480]
+* https://github.com/apache/logging-log4j2/pull/4077[Pull request that fixes the issue]
+
 [#CVE-2026-34479]
 == {cve-url-prefix}/CVE-2026-34479[CVE-2026-34479]
 

--- a/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
+++ b/src/site/antora/modules/ROOT/pages/_vulnerabilities.adoc
@@ -341,7 +341,7 @@ This issue was originally reported by Samuli Leinonen and independently reported
 [#CVE-2025-68161-description]
 === Description
 
-The Socket Appender in Log4j Core versions `2.0-beta9` through `2.25.2` does not perform TLS hostname verification of the peer certificate, even when the
+The Socket Appender in affected Log4j Core versions does not perform TLS hostname verification of the peer certificate, even when the
 https://logging.apache.org/log4j/2.x/manual/appenders/network.html#SslConfiguration-attr-verifyHostName[`verifyHostName`]
 configuration attribute or the
 https://logging.apache.org/log4j/2.x/manual/systemproperties.html#log4j2.sslVerifyHostName[`log4j2.sslVerifyHostName`]

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -90,6 +90,71 @@
   <vulnerabilities>
 
     <vulnerability>
+        <id>CVE-2026-34480</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-34480</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.9</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>116</cwe>
+        </cwes>
+        <description><![CDATA[Apache Log4j Core's
+https://logging.apache.org/log4j/2.x/manual/layouts.html#XmlLayout[`XmlLayout`],
+in versions up to and including 2.25.3, fails to sanitize characters forbidden by the
+https://www.w3.org/TR/xml/#charsets[XML 1.0 specification]
+producing invalid XML output whenever a log message or MDC value contains such characters.
+
+The impact depends on the StAX implementation in use:
+
+* *JRE built-in StAX:* Forbidden characters are silently written to the output, producing malformed XML.
+Conforming parsers must reject such documents with a fatal error, which may cause downstream log-processing systems to drop the affected records.
+* *Alternative StAX implementations* (e.g., https://github.com/FasterXML/woodstox[Woodstox], a transitive dependency of the Jackson XML Dataformat module): An exception is thrown during the logging call, and the log event is never delivered to its intended appender, only to Log4j's internal status logger.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4j Core version `2.25.4`, which corrects this issue by sanitizing forbidden characters before XML output.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>Ap4sh (Samy Medjahed)</name>
+                </individual>
+                <individual>
+                    <name>Ethicxz (Eliott Laurie)</name>
+                </individual>
+                <individual>
+                    <name>jabaltarik1</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4j-core</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:maven/>=2.0-alpha1|<2.25.4]]></range>
+                    </version>
+                    <version>
+                        <range><![CDATA[vers:maven/>=3.0.0-alpha1|<=3.0.0-beta3]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
+
+    <vulnerability>
         <id>CVE-2026-34479</id>
         <source>
             <name>NVD</name>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -90,6 +90,67 @@
   <vulnerabilities>
 
     <vulnerability>
+        <id>CVE-2026-40023</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-40023</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.3</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>116</cwe>
+        </cwes>
+        <description><![CDATA[Apache Log4cxx's
+https://logging.apache.org/log4cxx/1.7.0/classlog4cxx_1_1xml_1_1XMLLayout.html[`XMLLayout`],
+in versions before 1.7.0, fails to sanitize characters forbidden by the
+https://www.w3.org/TR/xml/#charsets[XML 1.0 specification]
+in log messages, NDC, and MDC property keys and values, producing invalid XML output.
+Conforming XML parsers must reject such documents with a fatal error, which may cause downstream log processing systems to drop or fail to index affected records.
+
+An attacker who can influence logged data can exploit this to suppress individual log records, impairing audit trails and detection of malicious activity.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4cxx version `1.7.0`, which fixes this issue.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>Olawale Titiloye</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4cxx</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:semver/>=0|<1.7.0]]></range>
+                    </version>
+                </versions>
+            </target>
+            <target>
+                <ref>log4cxx-conan</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:semver/>=0|<1.7.0]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
+
+    <vulnerability>
         <id>CVE-2026-40021</id>
         <source>
             <name>NVD</name>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -40,7 +40,7 @@
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns="http://cyclonedx.org/schema/bom/1.6"
      xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd"
-     version="7"
+     version="6"
      serialNumber="urn:uuid:dfa35519-9734-4259-bba1-3e825cf4be06">
 
   <metadata>
@@ -88,6 +88,65 @@
   </components>
 
   <vulnerabilities>
+
+    <vulnerability>
+        <id>CVE-2026-34478</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-34478</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.9</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>684</cwe>
+            <cwe>117</cwe>
+        </cwes>
+        <description><![CDATA[Apache Log4j Core's
+https://logging.apache.org/log4j/2.x/manual/layouts.html#RFC5424Layout[`Rfc5424Layout`],
+in versions 2.21.0 through 2.25.3, is vulnerable to log injection via CRLF sequences due to undocumented renames of security-relevant configuration attributes.
+
+Two distinct issues affect users of stream-based syslog services who configure `Rfc5424Layout` directly:
+
+* The `newLineEscape` attribute was silently renamed, causing newline escaping to stop working for users of TCP framing (RFC 6587), exposing them to CRLF injection in log output.
+* The `useTlsMessageFormat` attribute was silently renamed, causing users of TLS framing (RFC 5425) to be silently downgraded to unframed TCP (RFC 6587), without newline escaping.
+
+Users of the `SyslogAppender` are not affected, as its configuration attributes were not modified.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4j Core version `2.25.4`, which corrects this issue.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>Samuli Leinonen</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4j-core</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:maven/>=2.21.0|<2.25.4]]></range>
+                    </version>
+                    <version>
+                        <range><![CDATA[vers:maven/>=3.0.0-beta1|<=3.0.0-beta3]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
 
     <vulnerability>
         <id>CVE-2026-34477</id>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -90,6 +90,72 @@
   <vulnerabilities>
 
     <vulnerability>
+        <id>CVE-2026-34479</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-34479</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.9</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>116</cwe>
+        </cwes>
+        <description><![CDATA[The `Log4j1XmlLayout` from the Apache Log4j 1-to-Log4j 2 bridge fails to escape characters forbidden by the XML 1.0 standard, producing malformed XML output.
+Conforming XML parsers are required to reject documents containing such characters with a fatal error, which may cause downstream log processing systems to drop or fail to index affected records.
+
+Two groups of users are affected:
+
+* Those using `Log4j1XmlLayout` directly in a Log4j Core 2 configuration file.
+* Those using the Log4j 1 configuration compatibility layer with `org.apache.log4j.xml.XMLLayout` specified as the layout class.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4j 1-to-Log4j 2 bridge version `2.25.4`, which corrects this issue.
+
+NOTE: The Apache Log4j 1-to-Log4j 2 bridge is deprecated and will not be present in Log4j 3.
+Users are encouraged to consult the
+https://logging.apache.org/log4j/2.x/migrate-from-log4j1.html[Log4j 1 to Log4j 2 migration guide],
+and specifically the section on eliminating reliance on the bridge.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>Ap4sh (Samy Medjahed)</name>
+                </individual>
+                <individual>
+                    <name>Ethicxz (Eliott Laurie)</name>
+                </individual>
+                <individual>
+                    <name>jabaltarik1</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4j-1.2-api</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:maven/>=2.7|<2.25.4]]></range>
+                    </version>
+                    <version>
+                        <range><![CDATA[vers:maven/>=3.0.0-alpha1|<=3.0.0-beta2]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
+
+    <vulnerability>
         <id>CVE-2026-34478</id>
         <source>
             <name>NVD</name>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -618,7 +618,7 @@ This may prevent applications that consume these logs from correctly interpretin
         <![CDATA[Users are recommended to upgrade to version `1.5.0`, which fixes the issue.]]></recommendation>
       <created>2025-08-22T07:31:10Z</created>
       <published>2025-08-22T07:31:10Z</published>
-      <updated>2025-08-22T07:31:10Z</updated>
+      <updated>2026-04-10T11:53:17Z</updated>
       <credits>
         <organizations>
           <organization>
@@ -630,6 +630,14 @@ This may prevent applications that consume these logs from correctly interpretin
       <affects>
         <target>
           <ref>log4cxx</ref>
+          <versions>
+            <version>
+              <range><![CDATA[vers:semver>=0.11.0|<1.5.0]]></range>
+            </version>
+          </versions>
+        </target>
+        <target>
+          <ref>log4cxx-conan</ref>
           <versions>
             <version>
               <range><![CDATA[vers:semver>=0.11.0|<1.5.0]]></range>
@@ -676,7 +684,7 @@ Because logger names are generally constant strings, we assess the impact to use
         <![CDATA[Users are recommended to upgrade to version `1.5.0`, which fixes the issue.]]></recommendation>
       <created>2025-08-22T07:31:10Z</created>
       <published>2025-08-22T07:31:10Z</published>
-      <updated>2025-08-22T07:31:10Z</updated>
+      <updated>2026-04-10T11:53:17Z</updated>
       <credits>
         <organizations>
           <organization>
@@ -688,6 +696,14 @@ Because logger names are generally constant strings, we assess the impact to use
       <affects>
         <target>
           <ref>log4cxx</ref>
+          <versions>
+            <version>
+              <range><![CDATA[vers:semver<1.5.0]]></range>
+            </version>
+          </versions>
+        </target>
+        <target>
+          <ref>log4cxx-conan</ref>
           <versions>
             <version>
               <range><![CDATA[vers:semver<1.5.0]]></range>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -40,11 +40,11 @@
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns="http://cyclonedx.org/schema/bom/1.6"
      xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd"
-     version="5"
+     version="6"
      serialNumber="urn:uuid:dfa35519-9734-4259-bba1-3e825cf4be06">
 
   <metadata>
-    <timestamp>2025-12-18T16:09:38Z</timestamp>
+    <timestamp>2026-04-10T11:53:17Z</timestamp>
     <manufacturer>
       <name>Apache Logging Services</name>
       <url>https://logging.apache.org</url>
@@ -56,12 +56,34 @@
   <components>
     <component type="library" bom-ref="log4cxx">
       <name>Log4cxx</name>
+      <cpe>cpe:2.3:a:apache:log4cxx:*:*:*:*:*:*:*:*</cpe>
     </component>
-    <component type="library" bom-ref="pkg:maven/org.apache.logging.log4j/log4j-core?type=jar">
+    <component type="library" bom-ref="log4cxx-conan">
+      <name>Log4cxx</name>
+      <purl>pkg:conan/log4cxx</purl>
+    </component>
+    <component type="library" bom-ref="log4j-core">
       <group>org.apache.logging.log4j</group>
       <name>log4j-core</name>
       <cpe>cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*</cpe>
       <purl>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</purl>
+    </component>
+    <component type="library" bom-ref="log4j-1.2-api">
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-1.2-api</name>
+      <cpe>cpe:2.3:a:apache:log4j_1_2_api:*:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-1.2-api?type=jar</purl>
+    </component>
+    <component type="library" bom-ref="log4j-layout-template-json">
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-layout-template-json</name>
+      <cpe>cpe:2.3:a:apache:log4j_layout_template_json:*:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-layout-template-json?type=jar</purl>
+    </component>
+    <component type="library" bom-ref="log4net">
+      <name>Log4net</name>
+      <cpe>cpe:2.3:a:apache:log4net:*:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:nuget/log4net</purl>
     </component>
   </components>
 
@@ -107,7 +129,7 @@ For earlier versions, the risk can be reduced by carefully restricting the trust
         <updated>2025-12-18T16:09:38Z</updated>
         <affects>
             <target>
-                <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+                <ref>log4j-core</ref>
                 <versions>
                     <version>
                         <range><![CDATA[vers:maven/>=2.0-beta9|<2.25.3]]></range>
@@ -158,7 +180,7 @@ This may prevent applications that consume these logs from correctly interpretin
       </credits>
       <affects>
         <target>
-          <ref>logcxx</ref>
+          <ref>log4cxx</ref>
           <versions>
             <version>
               <range><![CDATA[vers:semver>=0.11.0|<1.5.0]]></range>
@@ -216,7 +238,7 @@ Because logger names are generally constant strings, we assess the impact to use
       </credits>
       <affects>
         <target>
-          <ref>logcxx</ref>
+          <ref>log4cxx</ref>
           <versions>
             <version>
               <range><![CDATA[vers:semver<1.5.0]]></range>
@@ -259,7 +281,7 @@ In prior releases confirm that if the JDBC Appender is being used it is not conf
       <updated>2025-08-17T11:18:06Z</updated>
       <affects>
         <target>
-          <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+          <ref>log4j-core</ref>
           <versions>
             <version>
               <range><![CDATA[vers:maven/>=2.0-beta7|<2.3.1]]></range>
@@ -332,7 +354,7 @@ Note that this mitigation is insufficient in releases older than `2.12.2` (for J
       </credits>
       <affects>
         <target>
-          <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+          <ref>log4j-core</ref>
           <versions>
             <version>
               <range><![CDATA[vers:maven/>=2.0-alpha1|<2.3.1]]></range>
@@ -416,7 +438,7 @@ Any other Lookup could also be included in a Thread Context Map variable and pos
       </credits>
       <affects>
         <target>
-          <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+          <ref>log4j-core</ref>
           <versions>
             <version>
               <range><![CDATA[vers:maven/>=2.0-beta9|<2.3.1]]></range>
@@ -487,7 +509,7 @@ An attacker who can control log messages or log message parameters can execute a
       </credits>
       <affects>
         <target>
-          <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+          <ref>log4j-core</ref>
           <versions>
             <version>
               <range><![CDATA[vers:maven/>=2.0-beta9|<2.3.1]]></range>
@@ -556,7 +578,7 @@ Alternatively, users can set the `mail.smtp.ssl.checkserveridentity` system prop
       </credits>
       <affects>
         <target>
-          <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+          <ref>log4j-core</ref>
           <versions>
             <version>
               <range><![CDATA[vers:maven/>=2.0-beta1|<2.3.2]]></range>
@@ -626,7 +648,7 @@ Java 6 users should avoid using the TCP or UDP socket server classes, or they ca
       </credits>
       <affects>
         <target>
-          <ref>pkg:maven/org.apache.logging.log4j/log4j-core?type=jar</ref>
+          <ref>log4j-core</ref>
           <versions>
             <version>
               <range><![CDATA[vers:maven/>=2.0-alpha1|<2.8.2]]></range>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -632,7 +632,7 @@ This may prevent applications that consume these logs from correctly interpretin
           <ref>log4cxx</ref>
           <versions>
             <version>
-              <range><![CDATA[vers:semver>=0.11.0|<1.5.0]]></range>
+              <range><![CDATA[vers:semver/>=0.11.0|<1.5.0]]></range>
             </version>
           </versions>
         </target>
@@ -640,7 +640,7 @@ This may prevent applications that consume these logs from correctly interpretin
           <ref>log4cxx-conan</ref>
           <versions>
             <version>
-              <range><![CDATA[vers:semver>=0.11.0|<1.5.0]]></range>
+              <range><![CDATA[vers:semver/>=0.11.0|<1.5.0]]></range>
             </version>
           </versions>
         </target>
@@ -671,7 +671,7 @@ This may prevent applications that consume these logs from correctly interpretin
         <cwe>117</cwe>
       </cwes>
       <description><![CDATA[When using `HTMLLayout`, logger names are not properly escaped when writing out to the HTML file.
-If untrusted data is used to retrieve the name of a logger, an attacker could theoretically inject HTML or Javascript in order to hide information from logs or steal data from the user.
+If untrusted data is used to retrieve the name of a logger, an attacker could theoretically inject HTML or JavaScript in order to hide information from logs or steal data from the user.
 In order to activate this, the following sequence must occur:
 
 * Log4cxx is configured to use `HTMLLayout`.
@@ -698,7 +698,7 @@ Because logger names are generally constant strings, we assess the impact to use
           <ref>log4cxx</ref>
           <versions>
             <version>
-              <range><![CDATA[vers:semver<1.5.0]]></range>
+              <range><![CDATA[vers:semver/<1.5.0]]></range>
             </version>
           </versions>
         </target>
@@ -706,7 +706,7 @@ Because logger names are generally constant strings, we assess the impact to use
           <ref>log4cxx-conan</ref>
           <versions>
             <version>
-              <range><![CDATA[vers:semver<1.5.0]]></range>
+              <range><![CDATA[vers:semver/<1.5.0]]></range>
             </version>
           </versions>
         </target>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -40,7 +40,7 @@
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns="http://cyclonedx.org/schema/bom/1.6"
      xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd"
-     version="6"
+     version="7"
      serialNumber="urn:uuid:dfa35519-9734-4259-bba1-3e825cf4be06">
 
   <metadata>
@@ -88,6 +88,89 @@
   </components>
 
   <vulnerabilities>
+
+    <vulnerability>
+        <id>CVE-2026-34477</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-34477</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.3</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>297</cwe>
+        </cwes>
+        <description><![CDATA[The fix for CVE-2025-68161 was incomplete: it addressed hostname verification only when enabled via the
+https://logging.apache.org/log4j/2.x/manual/systemproperties.html#log4j2.sslVerifyHostName[`log4j2.sslVerifyHostName`]
+system property, but not when configured through the
+https://logging.apache.org/log4j/2.x/manual/appenders/network.html#SslConfiguration-attr-verifyHostName[`verifyHostName`]
+attribute of the `<Ssl>` element.
+
+Although the `verifyHostName` configuration attribute was introduced in Log4j Core 2.12.0, it was silently ignored in all versions through 2.25.3, leaving TLS connections vulnerable to interception regardless of the configured value.
+
+A network-based attacker may be able to perform a man-in-the-middle attack when *all* of the following conditions are met:
+
+* An SMTP, Socket, or Syslog appender is in use.
+* TLS is configured via a nested `<Ssl>` element.
+* The attacker can present a certificate issued by a CA trusted by the appender's configured trust store, or by the default Java trust store if none is configured.
+
+This issue does not affect users of the HTTP appender, which uses a separate
+https://logging.apache.org/log4j/2.x/manual/appenders/network.html#HttpAppender-attr-verifyHostName[`verifyHostname`]
+attribute that was not subject to this bug and verifies host names by default.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4j Core version `2.25.4`, which corrects this issue.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>Samuli Leinonen</name>
+                </individual>
+                <individual>
+                    <name>Naresh Kandula</name>
+                </individual>
+                <individual>
+                    <name>Vitaly Simonovich</name>
+                </individual>
+                <individual>
+                    <name>Raijuna</name>
+                </individual>
+                <individual>
+                    <name>Danish Siddiqui</name>
+                </individual>
+                <individual>
+                    <name>Markus Magnuson</name>
+                </individual>
+                <individual>
+                    <name>Haruki Oyama</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4j-core</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:maven/>=2.12.0|<2.25.4]]></range>
+                    </version>
+                    <version>
+                        <range><![CDATA[vers:maven/>=3.0.0-alpha1|<=3.0.0-beta3]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
 
     <vulnerability>
         <id>CVE-2025-68161</id>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -90,6 +90,66 @@
   <vulnerabilities>
 
     <vulnerability>
+        <id>CVE-2026-34481</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-34481</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.3</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:H/AT:P/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>116</cwe>
+        </cwes>
+        <description><![CDATA[Apache Log4j's
+https://logging.apache.org/log4j/2.x/manual/json-template-layout.html[`JsonTemplateLayout`],
+in versions up to and including 2.25.3, produces invalid JSON output when log events contain non-finite floating-point values (`NaN`, `Infinity`, or `-Infinity`), which are prohibited by RFC 8259.
+This may cause downstream log processing systems to reject or fail to index affected records.
+
+An attacker can exploit this issue only if both of the following conditions are met:
+
+* The application uses `JsonTemplateLayout`.
+* The application logs a `MapMessage` containing an attacker-controlled floating-point value.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4j JSON Template Layout version `2.25.4`, which corrects this issue.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>Ap4sh (Samy Medjahed)</name>
+                </individual>
+                <individual>
+                    <name>Ethicxz (Eliott Laurie)</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4j-layout-template-json</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:maven/>=2.14.0|<2.25.4]]></range>
+                    </version>
+                    <version>
+                        <range><![CDATA[vers:maven/>=3.0.0-alpha1|<=3.0.0-beta3]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
+
+    <vulnerability>
         <id>CVE-2026-34480</id>
         <source>
             <name>NVD</name>

--- a/src/site/static/cyclonedx/vdr.xml
+++ b/src/site/static/cyclonedx/vdr.xml
@@ -90,6 +90,61 @@
   <vulnerabilities>
 
     <vulnerability>
+        <id>CVE-2026-40021</id>
+        <source>
+            <name>NVD</name>
+            <url>https://nvd.nist.gov/vuln/detail/CVE-2026-40021</url>
+        </source>
+        <ratings>
+            <rating>
+                <source>
+                    <name>The Apache Software Foundation</name>
+                    <url>
+                        <![CDATA[https://www.first.org/cvss/calculator/4-0#CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N]]></url>
+                </source>
+                <score>6.3</score>
+                <severity>medium</severity>
+                <method>CVSSv4</method>
+                <vector>AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N</vector>
+            </rating>
+        </ratings>
+        <cwes>
+            <cwe>116</cwe>
+        </cwes>
+        <description><![CDATA[Apache Log4net's
+https://logging.apache.org/log4net/manual/configuration/layouts.html#layout-list[`XmlLayout`]
+and
+https://logging.apache.org/log4net/manual/configuration/layouts.html#layout-list[`XmlLayoutSchemaLog4J`],
+in versions before 3.3.0, fail to sanitize characters forbidden by the
+https://www.w3.org/TR/xml/#charsets[XML 1.0 specification]
+in MDC property keys and values, as well as the identity field that may carry attacker-influenced data.
+This causes an exception during serialization and the silent loss of the affected log event.
+
+An attacker who can influence any of these fields can exploit this to suppress individual log records, impairing audit trails and detection of malicious activity.]]></description>
+        <recommendation><![CDATA[Users are advised to upgrade to Apache Log4net version `3.3.0`, which fixes this issue.]]></recommendation>
+        <created>2026-04-10T11:53:17Z</created>
+        <published>2026-04-10T11:53:17Z</published>
+        <updated>2026-04-10T11:53:17Z</updated>
+        <credits>
+            <individuals>
+                <individual>
+                    <name>f00dat</name>
+                </individual>
+            </individuals>
+        </credits>
+        <affects>
+            <target>
+                <ref>log4net</ref>
+                <versions>
+                    <version>
+                        <range><![CDATA[vers:nuget/>=0|<3.3.0]]></range>
+                    </version>
+                </versions>
+            </target>
+        </affects>
+    </vulnerability>
+
+    <vulnerability>
         <id>CVE-2026-34481</id>
         <source>
             <name>NVD</name>


### PR DESCRIPTION
Adds 8 new CVEs to the VDR and vulnerability page for the Log4j 2.25.4, Log4cxx 1.7.0, and Log4net 3.3.0 releases, and
extends the component list to support the new entries.

### New CVEs

| CVE            | Component                    | Summary                                                                               |
|----------------|------------------------------|---------------------------------------------------------------------------------------|
| CVE-2026-40023  | Log4cxx                      | Silent log event loss in `XMLLayout` (XML 1.0 forbidden chars)                        |
| CVE-2026-40021  | Log4net                      | Silent log event loss in `XmlLayout`/`XmlLayoutSchemaLog4J` (XML 1.0 forbidden chars) |
| CVE-2026-34481  | `log4j-layout-template-json` | Non-finite floats produce invalid JSON in `JsonTemplateLayout`                        |
| CVE-2026-34480  | `log4j-core`                 | Silent log event loss in `XmlLayout` (XML 1.0 forbidden chars)                        |
| CVE-2026-34479  | `log4j-1.2-api`              | Silent log event loss in `Log4j1XmlLayout` (XML 1.0 forbidden chars)                  |
| CVE-2026-34478  | `log4j-core`                 | Log injection in `Rfc5424Layout` via silent attribute renames                         |
| CVE-2026-34477  | `log4j-core`                 | `verifyHostName` attribute silently ignored in TLS configuration                      |

### Updates CVEs

| CVE            | Component                    | Summary                                                                               |
|----------------|------------------------------|---------------------------------------------------------------------------------------|
| CVE-2025-68161 | `log4j-core`                 | Update affected version range to include 3.0.0 pre-releases                           |

### Other changes

- Add `log4cxx` CPE, `log4cxx-conan`, `log4j-1.2-api`, `log4j-layout-template-json`, and `log4net` components to the VDR
- Fix `<ref>` typo `logcxx` → `log4cxx` in CVE-2025-54813 and CVE-2025-54812