### PR TITLE
Bump workflows to `gha/v0` branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ permissions: read-all
 jobs:
 
   build:
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@gha/v0
     with:
       java-version: 17
       site-enabled: true

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -27,7 +27,7 @@ permissions: read-all
 jobs:
 
   analyze:
-    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@gha/v0
     with:
       java-version: 17
       language: "actions"

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -29,7 +29,7 @@ jobs:
 
   deploy-site-stg:
     if: github.repository == 'apache/logging-site' && github.ref_name == 'main'
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@gha/v0
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -46,7 +46,7 @@ jobs:
 
   deploy-site-pro:
     if: github.repository == 'apache/logging-site' && github.ref_name == 'main-site-pro'
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@gha/v0
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}


### PR DESCRIPTION
This change switches the reusable workflows to the `gha/v0` branch to keep up to date with the action version whitelisted by the ASF.